### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TURIP
-version=0.2.1.2
+version=0.2.1-2
 author=TURIP project team
 maintainer=TURIP project team
 sentence=Server and client libraries of TURIP.


### PR DESCRIPTION
The previous version value caused the Arduino IDE to display warnings:
```
Invalid version found: 0.2.1.2
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format